### PR TITLE
Support for static "__hints__" property for dependency binding hints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,57 @@ facade = forge.get('facade')
 assert(facade.plugin instanceof BluePlugin)
 ```
 
+**NOTE**: This can also be done via a static property on your class named `__hints__`. This property
+is an object that contains the dependency mapping name, all boolean flag (optional), and hint (optional).
+
+The following example shows the equivalent static property `__hints__` implementation as the constructor
+string literal example.
+
+```coffeescript
+
+class TypeWithBindingHints
+  constructor: (@dep1, @dep2) ->
+    "dep1->a"
+    "dep2->b"
+
+# is equivalent to
+class TypeWithBindingHintsStatic
+  constructor: (@dep1, @dep2) ->
+  @__hints__:
+    dep1:
+      name: 'a'
+    dep2:
+      name: 'b'
+
+#---------------------------------------------
+
+class TypeWithAllBindingHint
+  constructor: (@deps) ->
+    "deps -> all dep"
+
+# is equivalent to
+class TypeWithAllBindingHintStatic
+  constructor: (@deps) ->
+  @__hints__:
+    deps:
+      name: 'dep'
+      all: true
+
+#---------------------------------------------
+
+class TypeWithConditionalBindingHint
+  constructor: (@dep) ->
+    "dep -> dep: foo"
+
+# is equivalent to
+class TypeWithConditionalBindingHintStatic
+  constructor: (@dep) ->
+  @__hints__:
+    dep:
+      name: 'dep'
+      hint: 'foo'
+```
+
 ## Lifecycles
 
 By default, once a binding has been resolved, the result will be cached and re-used for

--- a/src/Inspector.coffee
+++ b/src/Inspector.coffee
@@ -19,6 +19,10 @@ class Inspector
 
   getDependencyHints: (func) ->
     assert func?, 'The argument "func" must have a value'
+
+    if _.isObject(func.__hints__)
+      return func.__hints__
+
     regex = /"(.*?)\s*->\s*(all)?\s*(.*?)";/gi
     hints = {}
     while match = regex.exec(func.toString())

--- a/test/binding.tests.coffee
+++ b/test/binding.tests.coffee
@@ -2,7 +2,7 @@ expect          = require('chai').expect
 Forge           = require '../src/Forge'
 ResolutionError = require '../src/errors/ResolutionError'
 
-{Foo, Bar, DependsOnFoo, TypeWithBindingHints, TypeWithAllBindingHint, TypeWithConditionalBindingHint, DependsOnForge} = require './lib/types'
+{Foo, Bar, DependsOnFoo, TypeWithBindingHints, TypeWithAllBindingHint, TypeWithConditionalBindingHint, TypeWithBindingHintsStatic, TypeWithAllBindingHintStatic, TypeWithConditionalBindingHintStatic, DependsOnForge} = require './lib/types'
 
 describe 'Binding', ->
 
@@ -125,6 +125,46 @@ describe 'Binding', ->
       it 'should inject an instance of Foo into an instance of TypeWithConditionalBindingHint', ->
         result = forge.get('hints')
         expect(result).to.be.an.instanceOf(TypeWithConditionalBindingHint)
+        expect(result.dep).to.be.an.instanceOf(Foo)
+
+
+    describe 'given a binding to a type that contains binding hints via static property', ->
+
+      forge = new Forge()
+      forge.bind('a').to.type(Foo)
+      forge.bind('b').to.type(Bar)
+      forge.bind('hints').to.type(TypeWithBindingHintsStatic)
+
+      it 'should inject an instance of Foo and Bar into an instance of TypeWithBindingHints', ->
+        result = forge.get('hints')
+        expect(result).to.be.an.instanceOf(TypeWithBindingHintsStatic)
+        expect(result.dep1).to.be.an.instanceOf(Foo)
+        expect(result.dep2).to.be.an.instanceOf(Bar)
+
+    describe 'given a binding to a type that contains an "all" binding hint via static property', ->
+
+      forge = new Forge()
+      forge.bind('dep').to.type(Foo).when('foo')
+      forge.bind('dep').to.type(Bar).when('bar')
+      forge.bind('hints').to.type(TypeWithAllBindingHintStatic)
+
+      it 'should inject an array containing instances of Foo and Bar into an instance of TypeWithAllBindingHint', ->
+        result = forge.get('hints')
+        expect(result).to.be.an.instanceOf(TypeWithAllBindingHintStatic)
+        expect(result.deps).to.be.an.instanceOf(Array)
+        expect(result.deps[0]).to.be.an.instanceOf(Foo)
+        expect(result.deps[1]).to.be.an.instanceOf(Bar)
+
+    describe 'given a binding to a type that contains a conditional binding hint via static property', ->
+
+      forge = new Forge()
+      forge.bind('dep').to.type(Foo).when('foo')
+      forge.bind('dep').to.type(Bar).when('bar')
+      forge.bind('hints').to.type(TypeWithConditionalBindingHintStatic)
+
+      it 'should inject an instance of Foo into an instance of TypeWithConditionalBindingHint', ->
+        result = forge.get('hints')
+        expect(result).to.be.an.instanceOf(TypeWithConditionalBindingHintStatic)
         expect(result.dep).to.be.an.instanceOf(Foo)
 
 #---------------------------------------------------------------------------------------------------
@@ -342,7 +382,7 @@ describe 'Binding', ->
           forge.rebind('b').to.type(Bar)
           a = forge.get('a')
           expect(a).to.be.an.instanceOf(Foo)
-        
+
         it 'should return an instance of Bar when get() is called for "b"', ->
           forge.rebind('b').to.type(Bar)
           b = forge.get('b')
@@ -407,7 +447,7 @@ describe 'Binding', ->
 
       forge = new Forge()
       forge.bind('a').to.type(DependsOnForge)
-        
+
       it 'should inject the Forge when get() is called for "a"', ->
         a = forge.get('a')
         expect(a).to.be.an.instanceOf(DependsOnForge)

--- a/test/lib/types.coffee
+++ b/test/lib/types.coffee
@@ -20,6 +20,31 @@ class TypeWithConditionalBindingHint
   constructor: (@dep) ->
     "dep -> dep: foo"
 
+class TypeWithBindingHintsStatic
+  constructor: (@dep1, @dep2) ->
+  @__hints__:
+    dep1:
+      name: 'a'
+    dep2:
+      name: 'b'
+
+
+class TypeWithAllBindingHintStatic
+  constructor: (@deps) ->
+  @__hints__:
+    deps:
+      name: 'dep'
+      all: true
+
+
+class TypeWithConditionalBindingHintStatic
+  constructor: (@dep) ->
+  @__hints__:
+    dep:
+      name: 'dep'
+      hint: 'foo'
+
+
 class DependsOnForge
   constructor: (@forge) ->
 
@@ -49,6 +74,9 @@ module.exports = {
   TypeWithBindingHints
   TypeWithAllBindingHint
   TypeWithConditionalBindingHint
+  TypeWithBindingHintsStatic
+  TypeWithAllBindingHintStatic
+  TypeWithConditionalBindingHintStatic
   DependsOnForge
   CircularA
   CircularB


### PR DESCRIPTION
This is an optional approach to specify dependency hints on a class via a static property named **hints**. This property value matches the structure returned from Inspector.getDependencyHints. The purpose for this is to centrally store dependency names and reference these names without duplication of text. I can have a central store named `ForgeDependencies` and values like `ForgeDependencies.modules.foo` and `ForgeDependencies.modules2.bar`. I can then reference these values via this static property rather than string literals. See https://docs.angularjs.org/api/auto/service/$injector `$inject` property for this inspiration.
